### PR TITLE
fix(auth): use JwtRegisteredClaimNames.Sub for sub claim and adjust G…

### DIFF
--- a/PsychologySupport/ApiGateways/YarpApiGateway/Features/TokenExchange/Rules/TokenExchangeRuleRegistry.cs
+++ b/PsychologySupport/ApiGateways/YarpApiGateway/Features/TokenExchange/Rules/TokenExchangeRuleRegistry.cs
@@ -23,7 +23,7 @@ public class TokenExchangeRuleRegistry
             },
             new AudienceMappingRule
             {
-                Keywords = new[] { "profile" ,"subscription" },
+                Keywords = new[] { "profile" ,"subscription", "chatbox" },
                 ClaimType = "patientId",
                 LookupFunction = (subRef) => _piiLookupService.ResolvePatientIdBySubjectRefAsync(subRef)
             }

--- a/PsychologySupport/Services/ChatBox/ChatBox.API/Extensions/ClaimsPrincipleExtensions.cs
+++ b/PsychologySupport/Services/ChatBox/ChatBox.API/Extensions/ClaimsPrincipleExtensions.cs
@@ -56,4 +56,14 @@ public static class ClaimsPrincipalExtensions
 
         return roleClaims.Value;
     }
+
+    public static string GetSub(this ClaimsPrincipal user)
+    {
+        var sub = user.Claims.FirstOrDefault(c => c.Type == "sub" || c.Type == ClaimTypes.NameIdentifier)?.Value;
+
+        if (string.IsNullOrEmpty(sub))
+            throw new UnauthorizedAccessException("Token không hợp lệ: Không tìm thấy claim sub.");
+
+        return sub;
+    }
 }


### PR DESCRIPTION
…uid parsing

- Updated GenerateJWTToken to issue 'sub' claim using JwtRegisteredClaimNames.Sub
- Added ClaimTypes.Authentication claim for onboarding status
- Extracted sub from Claims using JwtRegisteredClaimNames.Sub or ClaimTypes.NameIdentifier
- Fixed Guid conversion by parsing sub value before passing to methods requiring Guid